### PR TITLE
accept spaces in Search class

### DIFF
--- a/eol_api_wrapper.py
+++ b/eol_api_wrapper.py
@@ -199,7 +199,7 @@ class Search(object):
 
         if not isinstance(page, int) and page!='all':
             raise ValueError('Not a valid page number')
-
+        q = q.replace(' ', '+')  # prep search strings for the url syntax.
         attributes = [q,page,API._bool_converter(exact),filter_by_taxon_concept_id, filter_by_hierarchy_entry_id, filter_by_string, cache_ttl, key]
 
         url = (


### PR DESCRIPTION
Adjusts the Search class to accept spaces in query strings. 
ie: 'Saiga tatarica' will be changed to the URL appropriate syntax 'Saiga+tatarica' behind the scenes.

This was useful for my use, so I'm proposing it upstream. It should be tested with other use cases to be sure it does not break anything. 